### PR TITLE
Close #10 #7: add pkg-config install for brew

### DIFF
--- a/vsfm_os_x_installer.sh
+++ b/vsfm_os_x_installer.sh
@@ -125,6 +125,7 @@ function installBrews () {
 		brew tap homebrew/versions
 		brew install gcc48
 		brew install devil
+		brew install pkg-config
 #maybe....
 #		brew install mesalib-glw
 


### PR DESCRIPTION
The line in the install script output reported by two of the users (and experienced by me): 
"make: /usr/local/bin/pkg-config: Command not found"
Caused me to make a link from my pkg-config I already had to /usr/local/bin/pkg-config. This didn't help much as that copy of pkg-config had no idea where all the .pc library files were. As I started manually adding the paths to the .pc files needed to pkg-config's search path, I eventually realized that there had to be a much better way. On a hunch, I installed a new copy of pkg-config from brew and successfully compiled visualSFM.

Because the pkg-config installed by brew needs to be run, I suspect that luckybulldozer/VisualSFM_OS_X_Installer#12 might just be using the wrong pkg-config and possibly fixed by this change as well.

Close luckybulldozer/VisualSFM_OS_X_Installer#10 luckybulldozer/VisualSFM_OS_X_Installer#7
